### PR TITLE
msg-colours: Add support for setting colours to messages via mqtt

### DIFF
--- a/micropython/ReadMe.md
+++ b/micropython/ReadMe.md
@@ -9,6 +9,7 @@ An edited version of the Pimoroni Text Scroll to connect to Wifi and subscribe t
 
 Copy all the files to your Galactic Unicon using Thonny - edit config.py to add your Wifi and MQTT broker credentials.
 
-Edit the unicornmqttscroller.py file for your own MQTTT to subscribe, background colour, scroll speed etc.
+Edit the unicornmqttscroller.py file for your own MQTT to subscribe, background colour, scroll speed etc.
+You may also rename this file to `main.py` so it starts automatically.
 
 Created as part of work at the Connected Environments Group at the Centre for Advanced Spatial Analysis, University College London.

--- a/micropython/config.py
+++ b/micropython/config.py
@@ -5,13 +5,16 @@ from mqtt_as import config
 config['server'] = ''  # Your MQTT Server
 #  config['server'] = 'test.mosquitto.org'
 
-config ['port'] = 1884 #Your MQTT Port
+config ['port'] = 1883 #Your MQTT Port
 config['user'] ='' #Your MQTT User Name
 config ['password'] ='' # Your MQTT Password
 
 
 config['ssid'] = '' #Your Wifi SSID
 config['wifi_pw'] = '' #Your Wifi Password
+
+
+TOPIC_PREFIX = 'galactic'
 
 # For demos ensure same calling convention for LED's on all platforms.
 # ESP8266 Feather Huzzah reference board has active low LED's on pins 0 and 2.

--- a/micropython/unicornmqttscroller.py
+++ b/micropython/unicornmqttscroller.py
@@ -12,15 +12,17 @@
 # blue LED heartbeat: demonstrates scheduler is running.
 
 
-
-#Import libraries - config.py sets up wifi and mqtt
+# Import libraries - config.py sets up wifi and mqtt
 import time
+import network
 from galactic import GalacticUnicorn
 from picographics import PicoGraphics, DISPLAY_GALACTIC_UNICORN as DISPLAY
-
+import json
+import re
+import urandom
 
 from mqtt_as import MQTTClient, config
-from config import wifi_led, blue_led  # Local definitions
+from config import wifi_led, blue_led, TOPIC_PREFIX  # Local definitions
 import uasyncio as asyncio
 import machine
 from machine import Pin, PWM
@@ -32,10 +34,11 @@ PADDING = 2
 MESSAGE_COLOUR = (255, 255, 255)
 OUTLINE_COLOUR = (0, 0, 0)
 MESSAGE = ""
-#BACKGROUND_COLOUR = (10, 0, 96) # Blue
-BACKGROUND_COLOUR = (255, 255, 0) # Yellow
+# BACKGROUND_COLOUR = (10, 0, 96) # Blue
+BACKGROUND_COLOUR = (255, 255, 0)  # Yellow
 HOLD_TIME = 2.0
-STEP_TIME = 0.045 #Edit to slow down/speed up text - lower for faster scrolling
+STEP_TIME = 0.045  # Edit to slow down/speed up text - lower for faster scrolling
+
 
 # create galactic object and graphics surface for drawing
 gu = GalacticUnicorn()
@@ -52,6 +55,48 @@ STATE_POST_SCROLL = 2
 shift = 0
 state = STATE_PRE_SCROLL
 
+# Global variables
+stats = {
+    "wifi_connection": 0,
+    "mqtt_connection": 0,
+    "msg_cb": 0,
+    "uptime_minutes": 0,
+}
+wifi_is_up = False
+ip_address = "0.0.0.0"
+ping_event = asyncio.Event()  # Create an asyncio Event
+
+# Define known colours
+KNOWN_COLOURS = {
+    "red": (255, 0, 0),
+    "green": (0, 255, 0),
+    "blue": (0, 0, 255),
+    "yellow": (255, 255, 0),
+    "magenta": (255, 0, 255),
+    "purple": (128, 0, 128),
+    "cyan": (0, 255, 255),
+    "orange": (255, 165, 0),
+    "black": (0, 0, 0),
+    "none": (0, 0, 0),
+    "nil": (0, 0, 0),
+    "null": (0, 0, 0),
+    "white": (255, 255, 255),
+    "gray": (128, 128, 128),
+    "grey": (128, 128, 128),  # Alternate spelling
+    "pink": (255, 192, 203),
+    "brown": (165, 42, 42),
+    "lime": (0, 255, 0),
+    "navy": (0, 0, 128),
+    "teal": (0, 128, 128),
+    "olive": (128, 128, 0),
+    "maroon": (128, 0, 0),
+    "aqua": (0, 255, 255),
+    "silver": (192, 192, 192),
+    "gold": (255, 215, 0),
+    "beige": (245, 245, 220),
+    "violet": (238, 130, 238),
+}
+
 # set the font
 graphics.set_font("bitmap8")
 
@@ -61,12 +106,148 @@ msg_width = graphics.measure_text(MESSAGE, 1)
 last_time = time.ticks_ms()
 
 
+def simple_split(input_string):
+    # Manually split the string by non-lowercase alphabet characters
+    word = ""
+    words = []
+    for char in input_string:
+        if "a" <= char <= "z":  # Check if the character is between 'a' and 'z'
+            word += char
+        else:
+            if word:  # If a word is collected, add it to the list
+                words.append(word)
+                word = ""  # Reset the word
+    if word:  # Add the last word if there is one
+        words.append(word)
+    return words
+
+
+def pick_colour(input_string):
+    words = simple_split(input_string)
+    # Set comprehension for words not in KNOWN_COLOURS
+    cmd_in_words = {word for word in words if word not in KNOWN_COLOURS}
+
+    # List comprehension for colours that exist in KNOWN_COLOURS. Repeats increases chance of colour.
+    given_colours = [word for word in words if word in KNOWN_COLOURS]
+
+    # if no colours are provided, we will use them all as potential values
+    if not given_colours:
+        # no colours we know about. Make sure that there is at least a "random" or "pick" mentioned
+        if not cmd_in_words.intersection({"random", "select", "pick", "choose", "any"}):
+            return
+        keys = tuple(KNOWN_COLOURS.keys())  # Convert keys to a tuple once
+    elif cmd_in_words.intersection(
+        {"not", "no", "ignore", "exclude", "minus", "except", "remove", "nor"}
+    ):
+        ## Assuming there are unique values for every colour, this should do it
+        ## keys = tuple([word for word in KNOWN_COLOURS if word not in set(given_colours)])
+        ## But since there are repeated values for colours (like gray and grey), we need to look at values
+        ## to know for cetain what to exclude.
+        unwanted_values = {KNOWN_COLOURS[given_colour] for given_colour in given_colours}
+        keys = tuple(
+            [word for word in KNOWN_COLOURS if KNOWN_COLOURS[word] not in unwanted_values]
+        )
+    else:
+        keys = tuple(given_colours)
+
+    random_key = keys[urandom.getrandbits(8) % len(keys)]  # Randomly select a key
+    return KNOWN_COLOURS[random_key]
+
+
+def parse_rgb(colour_str, retry=0):
+    if retry > 1:
+        return None
+    if colour_str is None:
+        return None
+
+    try:
+        # Remove any square, curly, round braces, and whitespace from the string
+        colour_str = re.sub(r"[\[\]\(\)\{\}\s]", "", colour_str)
+
+        # Split the string by commas
+        parts = colour_str.split(",")
+
+        # special cases
+        if len(parts) > 0 and retry == 1:
+            # 0
+            if parts[0] == "0" or not parts[0]:
+                parts = ["0", "0", "0"]
+            else:
+                return pick_colour(colour_str.lower())
+
+        # Convert each part to an integer, interpreting as hex if it starts with '0x'
+        r, g, b = [
+            (
+                int(part.strip(), 16)
+                if part.strip().lower().startswith("0x")
+                else int(part.strip())
+            )
+            for part in parts
+        ]
+
+        # Ensure the values are within the valid range
+        if 0 <= r <= 255 and 0 <= g <= 255 and 0 <= b <= 255:
+            return (r, g, b)
+
+    except TypeError:
+        pass  # Implicit return None
+    except ValueError:
+        pass  # Implicit return None
+
+    # Recurse call to try parsing value as a string
+    return parse_rgb(str(colour_str), retry + 1)
+
+
+def parse_msg(msg):
+    try:
+        # Attempt to parse the message as JSON
+        data = json.loads(msg)
+
+        # Extract text or use empty string if not found
+        text = data.get("msg", data.get("text", data.get("txt", msg)))
+        text_colour = data.get(
+            "msg_colour", data.get("text_colour", data.get("txt_colour", msg)))
+        # Support spelling of colour without the u
+        if text_colour is None:
+            text_colour = data.get(
+                "msg_color", data.get("text_color", data.get("txt_color", msg)))
+        )
+
+        # Parse colours if present, or fall back to defaults
+        bg_colour_value = data.get("bg_colour", data.get("bg_color"))
+        bg_colour = parse_rgb(bg_colour_value) or BACKGROUND_COLOUR
+        outline_colour_value = data.get("outline_colour", data.get("outline_color"))
+        outline_colour = parse_rgb(outline_colour_value) or OUTLINE_COLOUR
+        msg_colour = parse_rgb(text_colour) or MESSAGE_COLOUR
+
+        return text, bg_colour, outline_colour, msg_colour
+    except ValueError:
+        # If the message is not valid JSON, return the defaults
+        return msg, BACKGROUND_COLOUR, OUTLINE_COLOUR, MESSAGE_COLOUR
+
+
 # MQTT Message Subscription and Display
 
+
 def sub_cb(topic, msg, retained):
-    print(f'Topic: "{topic.decode()}" Message: "{msg.decode()}" Retained: {retained}')
-    
-        
+    global stats
+
+    topic_str = topic.decode()
+    print(f'Topic: "{topic_str}" Message: "{msg.decode()}" Retained: {retained}')
+
+    if topic_str.lower().endswith("/status"):
+        return
+
+    if topic_str.lower().endswith("/ping"):
+        ping_event.set()
+        return
+
+    stats["msg_cb"] += 1
+
+    # go no further if this is not a msg topic
+    if not topic_str.lower().endswith("/msg"):
+        return
+
     # state constants
     brightness = 0.5
     gu.set_brightness(brightness)
@@ -76,8 +257,13 @@ def sub_cb(topic, msg, retained):
 
     shift = 0
     state = STATE_PRE_SCROLL
-    def outline_text(text, x, y):
-        graphics.set_pen(graphics.create_pen(int(OUTLINE_COLOUR[0]), int(OUTLINE_COLOUR[1]), int(OUTLINE_COLOUR[2])))
+
+    def outline_text(text, outline_colour, msg_colour, x, y):
+        graphics.set_pen(
+            graphics.create_pen(
+                int(outline_colour[0]), int(outline_colour[1]), int(outline_colour[2])
+            )
+        )
         graphics.text(text, x - 1, y - 1, -1, 1)
         graphics.text(text, x, y - 1, -1, 1)
         graphics.text(text, x + 1, y - 1, -1, 1)
@@ -87,20 +273,22 @@ def sub_cb(topic, msg, retained):
         graphics.text(text, x, y + 1, -1, 1)
         graphics.text(text, x + 1, y + 1, -1, 1)
 
-        graphics.set_pen(graphics.create_pen(int(MESSAGE_COLOUR[0]), int(MESSAGE_COLOUR[1]), int(MESSAGE_COLOUR[2])))
+        graphics.set_pen(
+            graphics.create_pen(int(msg_colour[0]), int(msg_colour[1]), int(msg_colour[2]))
+        )
         graphics.text(text, x, y, -1, 1)
-    
-    DATA = (msg.decode('utf-8'))
+
+    DATA, bg_colour, outline_colour, msg_colour = parse_msg(msg.decode("utf-8"))
+    if not DATA:
+        print("Ignoring empty payload")
+        return
+
     MESSAGE = str("                " + DATA + "             ")
-    
-# calculate the message width so scrolling can happen
+    # calculate the message width so scrolling can happen
     msg_width = graphics.measure_text(MESSAGE, 1)
-
     last_time = time.ticks_ms()
-       
+    print(DATA)
 
-    print (MESSAGE)
-    
     while True:
         time_ms = time.ticks_ms()
 
@@ -122,81 +310,156 @@ def sub_cb(topic, msg, retained):
                 brightness = 0
                 gu.set_brightness(brightness)
                 gu.update(graphics)
+                print("message display finished")
                 break
+
             last_time = time_ms
-           
 
         if state == STATE_POST_SCROLL and time_ms - last_time > HOLD_TIME * 1000:
             state = STATE_PRE_SCROLL
             shift = 0
             last_time = time_ms
-            
 
-        graphics.set_pen(graphics.create_pen(int(BACKGROUND_COLOUR[0]), int(BACKGROUND_COLOUR[1]), int(BACKGROUND_COLOUR[2])))
+        graphics.set_pen(
+            graphics.create_pen(int(bg_colour[0]), int(bg_colour[1]), int(bg_colour[2]))
+        )
         graphics.clear()
 
-        outline_text(MESSAGE, x=PADDING - shift, y=2)
+        outline_text(MESSAGE, outline_colour, msg_colour, x=PADDING - shift, y=2)
 
         # update the display
         gu.update(graphics)
 
         # pause for a moment (important or the USB serial device will fail)
         time.sleep(0.001)
-    
-    
-    
+
+
+# Get the IP address
+def get_ip_address():
+    sta_if = network.WLAN(network.STA_IF)
+    return sta_if.ifconfig()[0] if sta_if.isconnected() else "0.0.0.0"
+
+
 # Demonstrate scheduler is operational.
 async def heartbeat():
+    # Rates for the heart
+    # fast = no wifi
+    # 1 sec = no mqtt
+    # 3 sec = all good, hopefully
     s = True
     while True:
-        await asyncio.sleep_ms(500)
+        if not wifi_is_up:
+            sleep_value = 250
+        else:
+            sleep_value = 1000 if stats["mqtt_connection"] == 0 else 3000
+        await asyncio.sleep_ms(sleep_value)
         blue_led(s)
         s = not s
 
+
+# Count for how long the board has been operational
+async def updateuptime():
+    global stats
+
+    while True:
+        await asyncio.sleep(60)
+        stats["uptime_minutes"] += 1  # Increment uptime count
+
+
 async def wifi_han(state):
+    global stats
+    global ip_address
+    global wifi_is_up
+
+    wifi_is_up = state
     wifi_led(not state)
-    print('Wifi is ', 'up' if state else 'down')
-   # sweep()
+    if state:  # WiFi is up
+        stats["wifi_connection"] += 1  # Increment connection count
+        ip_address = get_ip_address()
+    else:
+        stats["mqtt_connection"] = 0
+    print(
+        "WiFi is",
+        "UP." if state else "DOWN.",
+        f"Address is {ip_address}.",
+        "Wifi up count",
+        stats["wifi_connection"],
+    )
     await asyncio.sleep(1)
+
 
 # If you connect with clean_session True, must re-subscribe (MQTT spec 3.1.2.4)
 async def conn_han(client):
-    
-# MQTT Subscirbe Topic   
-    await client.subscribe('personal/ucfnaps/led/#', 1)
+    global stats
+    stats["mqtt_connection"] += 1  # Increment connection count
+    # await client.subscribe(TOPIC_PREFIX + "/#", 1)
+    await client.subscribe(TOPIC_PREFIX + "/msg", 1)
+    await client.subscribe(TOPIC_PREFIX + "/ping", 1)
+    print("mqtt connected", stats["mqtt_connection"], "times now")
+    ping_event.set()
+
 
 async def main(client):
+    print("starting\n")
     try:
         await client.connect()
     except OSError:
-        print('Connection failed.')
+        print("Connection failed.")
+        await asyncio.sleep(15)
         machine.reset()
         return
+
     n = 0
-    while True:
-        await asyncio.sleep(5)
-       # print('publish', n)
-        # If WiFi is down the following will pause for the duration.
-        #await client.publish('result', '{} {}'.format(n, client.REPUB_COUNT), qos = 1)
-        n += 1
+    tick_sleep = 1800
+    try:
+        while True:
+            n += 1
+
+            # Wait for the tick_sleep or an external event
+            try:
+                await asyncio.wait_for(ping_event.wait(), tick_sleep)
+                ping_event.clear()
+                print("publish from ping/mqtt_connect", n)
+            except asyncio.TimeoutError:
+                print("publish", n)
+                pass  # Timeout indicates tick_sleep passed without event being set
+
+            payload_dict = {
+                "repub_count": client.REPUB_COUNT,
+                "ip_address": ip_address,
+                "mqtt_connection_count": stats["mqtt_connection"],
+                "wifi_connection_count": stats["wifi_connection"],
+                "msg_cb_count": stats["msg_cb"],
+                "uptime_minutes": stats["uptime_minutes"],
+            }
+            payload = json.dumps(payload_dict)
+
+            # If WiFi is down the following will pause for the duration.
+            await client.publish(TOPIC_PREFIX + "/status", payload, qos=0)
+            await asyncio.sleep(urandom.getrandbits(2))
+    except Exception as e:
+        print("Failed:", e)
+        await asyncio.sleep(15)
+        machine.reset()
+        return
+
 
 # Define configuration
-config['subs_cb'] = sub_cb
-config['wifi_coro'] = wifi_han
-config['connect_coro'] = conn_han
-config['clean'] = True
+config["subs_cb"] = sub_cb
+config["wifi_coro"] = wifi_han
+config["connect_coro"] = conn_han
+config["clean"] = True
 
 # Set up client
-MQTTClient.DEBUG = True  # Optional
-client = MQTTClient(config)
+MQTTClient.DEBUG = False  # Optional
 
+client = MQTTClient(config)
 asyncio.create_task(heartbeat())
+asyncio.create_task(updateuptime())
 
 
 try:
     asyncio.run(main(client))
-    
-
 finally:
     client.close()  # Prevent LmacRxBlk:1 errors
     asyncio.new_event_loop()

--- a/util/galactic.sh
+++ b/util/galactic.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# galactic.sh: a script to periodically cause galactic Unicorn to display a message
+#
+# Usage example:  ./galactic.sh "This is a test" 10
+
+# set -xe
+
+export msg=${msg:-$1}
+export interval=${interval:-$2}
+export counter=${counter:-$3}
+
+# NOTE: This is possibly not the proper MQTT broker (see config.py)
+export MQTT='test.mosquitto.org'
+
+[ -n "${msg}" ] || msg='This is a test message. Have a great day'
+[ -n "${interval}" ] || interval=60
+[ -n "${counter}" ] || counter=0
+
+while : ; do
+    now=$(date "+%D %T")
+    payload=$(jq -c -n \
+                 --arg counter "$counter" \
+                 --arg msg "$now $msg" \
+                 --arg outline_colour "black_or_brown" \
+                 --arg msg_colour "any_except_black_or_brown" \
+                 '{"msg": "\($msg) \($counter)", "outline_colour": "\($outline_colour)", "msg_colour": "\($msg_colour)", "bg_colour": "random"}')
+
+    echo $payload
+
+    # NOTE: This is assuming that TOPIC_PREFIX (see config.py) is "galactic"
+    mosquitto_pub -h "$MQTT" -t "galactic/msg" -m "$payload" ||:
+    # mosquitto_pub -h "$MQTT" -t "galactic/ping" -n ||:
+
+    sleep $interval
+    counter=$((counter + 1))
+done

--- a/util/proverbs.sh
+++ b/util/proverbs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# proverbs.sh: a script to periodically cause galactic Unicorn to display a proverb
+#
+# Usage example:  ./proverbs.sh 25
+
+set -e
+
+export interval=${interval:-$1}
+
+# NOTE: This is possibly not the proper MQTT broker (see config.py)
+export MQTT='test.mosquitto.org'
+
+[ -n "${interval}" ] || interval=60
+
+[ -s "/tmp/proverbs.txt" ] || curl --silent -L --max-time 10 -o /tmp/proverbs.txt \
+   https://raw.githubusercontent.com/alltom/proverb/master/proverbs.txt
+
+while : ; do
+    # Pick a random proverb
+    msg=$(shuf -n 1 /tmp/proverbs.txt)
+    
+    payload=$(jq -c -n \
+                 --arg msg "$msg" \
+                 --arg outline_colour "black" \
+                 --arg msg_colour "any_except_black_or_brown" \
+                 '{"msg": "\($msg)", "outline_colour": "\($outline_colour)", "msg_colour": "\($msg_colour)", "bg_colour": "random"}')
+
+    echo $payload
+    
+    # NOTE: This is assuming that TOPIC_PREFIX (see config.py) is "galactic"
+    mosquitto_pub -h "$MQTT" -t "galactic/msg" -m "$payload" ||:
+
+    # Add jitter sleep of 0 to 15 seconds
+    jitter=$(shuf -i 0-15 -n 1)
+    sleep $jitter
+    
+    sleep $interval
+done


### PR DESCRIPTION
- Imports and Dependencies:
  - Added json, re, urandom, and network modules.
  - Updated imports from config.py to include TOPIC_PREFIX.

- Global Variables:
  - Introduced variables for WiFi and MQTT connection states.
  - Added a stats dictionary to track uptime, connection and message states.

- Colour Management:
  - Added a KNOWN_COLOURS dictionary for colour name-to-RGB mapping.
  - JSON message support for configuring msg, outline, and background colours.

- MQTT Subscriptions:
  - Added subscription to {TOPIC_PREFIX}/ping and {TOPIC_PREFIX}/msg and publishing response with operational status on {TOPIC_PREFIX}/status.

- Examples JSON for setting colours:

  $ mosquitto_pub -h ${MQTT_BROKER} -t galactic/msg -m ' {"msg":"Have a great day", "outline_colour":"yellow_or_green", "msg_colour":"random_except:black,brown", "bg_colour":"random"} ' $ mosquitto_pub -h ${MQTT_BROKER} -t 'galactic/msg' -m '{"msg":"blue message", "msg_colour":"[0,0,255]"}'

  $ # To explicitly trigger a galactic/status... $ mosquitto_pub -h ${MQTT_BROKER} -t 'galactic/ping' -n

- Example status response:

  $ mosquitto_sub -F '@Y-@m-@dT@H:@M:@S@z : %q : %t : %p' -h ${MQTT_BROKER} -t "galactic/#"

  galactic/status : {"repub_count": 0, "wifi_connection_count": 1, "mqtt_connection_count": 1, "ip_address": "192.168.123.123", "msg_cb_count": 5, "uptime_minutes": 5}